### PR TITLE
Upgrade docker-client to 8.9.2

### DIFF
--- a/platform-controller/pom.xml
+++ b/platform-controller/pom.xml
@@ -79,9 +79,14 @@
         </dependency>
         <!-- Docker Client -->
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.4-jre</version>
+        </dependency>
+        <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>6.1.0</version>
+            <version>8.9.2</version>
         </dependency>
         <!-- JSON lib -->
         <dependency>

--- a/platform-controller/pom.xml
+++ b/platform-controller/pom.xml
@@ -77,12 +77,13 @@
             <artifactId>amqp-client</artifactId>
             <version>3.6.0</version>
         </dependency>
-        <!-- Docker Client -->
+        <!-- Guava (there only to mitigate version conflicts) -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.4-jre</version>
+            <version>20.0</version>
         </dependency>
+        <!-- Docker Client -->
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -36,7 +36,6 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.ContainerNotFoundException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.AttachedNetwork;
-import com.spotify.docker.client.messages.AuthConfig;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
@@ -46,6 +45,7 @@ import com.spotify.docker.client.messages.Image;
 import com.spotify.docker.client.messages.LogConfig;
 import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.NetworkConfig;
+import com.spotify.docker.client.messages.RegistryAuth;
 
 /**
  * Created by Timofey Ermilov on 31/08/16
@@ -96,7 +96,7 @@ public class ContainerManagerImpl implements ContainerManager {
     /**
      * Authentication configuration for accessing private repositories.
      */
-    private final AuthConfig gitlabAuth;
+    private final RegistryAuth gitlabAuth;
     /**
      * Observers that should be notified if a container terminates.
      */
@@ -120,7 +120,7 @@ public class ContainerManagerImpl implements ContainerManager {
         String registryUrl = System.getenv().containsKey(REGISTRY_URL_KEY) ? System.getenv(REGISTRY_URL_KEY)
                 : "git.project-hobbit.eu:4567";
         if ((username != null) && (password != null)) {
-            gitlabAuth = AuthConfig.builder().serverAddress(registryUrl).username(username).password(password)
+            gitlabAuth = RegistryAuth.builder().serverAddress(registryUrl).username(username).password(password)
                     .email(email).build();
         } else {
             LOGGER.warn(


### PR DESCRIPTION
We need to upgrade docker-client to be able to work with new swarm.

I've set guava dependency because otherwise it has conflict (`java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument` called from docker-client). Maybe there is better way to resolve that?