### PR TITLE
Feature/issue89 internal queue security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ redeploy-gui:
 	docker-compose build
 	docker-compose up -d gui
 
+redeploy-storage:
+	cd platform-storage/storage-service && mvn clean package -U
+	docker-compose build
+	docker-compose up -d storage-service
+
 start:
 	docker-compose build
 	docker-compose up

--- a/analysis-component/pom.xml
+++ b/analysis-component/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.hobbit</groupId>
             <artifactId>core</artifactId>
-            <version>1.0.8-SNAPSHOT</version>
+            <version>1.0.9-SNAPSHOT</version>
         </dependency>
         <!-- RabbitMQ -->
         <dependency>

--- a/platform-storage/storage-service/pom.xml
+++ b/platform-storage/storage-service/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.hobbit</groupId>
             <artifactId>core</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9-SNAPSHOT</version>
         </dependency>
         <!-- RabbitMQ -->
         <dependency>

--- a/platform-storage/storage-service/src/main/java/org/hobbit/storage/service/DeliveryProcessing.java
+++ b/platform-storage/storage-service/src/main/java/org/hobbit/storage/service/DeliveryProcessing.java
@@ -56,7 +56,6 @@ public class DeliveryProcessing implements Runnable {
             String query = null;
             byte[] message = delivery.getBody();
             if(encryption != null) {
-                LOGGER.error(new String(message));
                 byte[] decryptedMessage = encryption.decrypt(message);
                 query = new String(decryptedMessage);
             } else {


### PR DESCRIPTION
Solves issue #89 .

The required configuration for the services are (docker-compose.override.yml):
```
version: '2'
services:
  platform-controller:
    environment:
      AES_PASSWORD: "password"
      AES_SALT: "salt"

  gui:
    environment:
      AES_PASSWORD: "password"
      AES_SALT: "salt"

  storage-service:
    environment:
      AES_PASSWORD: "password"
      AES_SALT: "salt"

  analysis:
    environment:
      AES_PASSWORD: "password"
      AES_SALT: "salt"
```

AES_PASSWORD and AES_SALT can be set to any value, but should be the same across all the services.