### PR TITLE
Feature/issue97 cluster healthchecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ redeploy-gui:
 	docker-compose build
 	docker-compose up -d gui
 
+redeploy-controller:
+	cd platform-controller && make build
+	docker-compose build
+	docker-compose up -d platform-controller
+
 start:
 	docker-compose build
 	docker-compose up

--- a/platform-controller/pom.xml
+++ b/platform-controller/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.hobbit</groupId>
             <artifactId>core</artifactId>
-            <version>1.0.9-res-SNAPSHOT</version>
+            <version>1.0.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -378,9 +378,9 @@ public class ExperimentManager implements Closeable {
                 ClusterManager clusterManager = new ClusterManagerImpl();
                 boolean isHealthy = clusterManager.isClusterHealthy();
                 if(!isHealthy) {
-                    LOGGER.error("Cluster became unhealthy during the experiment! Some nodes are down.");
-                    LOGGER.error("Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
-                            "Current number of nodes: "+clusterManager.getNumberOfNodes());
+                    LOGGER.error("Cluster became unhealthy during the experiment! Some nodes are down." +
+                            " Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
+                            " Current number of nodes: "+clusterManager.getNumberOfNodes());
 
                     experimentStatus.addError(HobbitErrors.ClusterNotHealthy);
                 }

--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -40,7 +40,6 @@ import org.hobbit.controller.data.ExperimentConfiguration;
 import org.hobbit.controller.data.ExperimentStatus;
 import org.hobbit.controller.data.ExperimentStatus.States;
 import org.hobbit.controller.docker.ClusterManager;
-import org.hobbit.controller.docker.ClusterManagerImpl;
 import org.hobbit.controller.docker.MetaDataFactory;
 import org.hobbit.controller.execute.ExperimentAbortTimerTask;
 import org.hobbit.core.Commands;
@@ -152,7 +151,7 @@ public class ExperimentManager implements Closeable {
         try {
             // if there is no benchmark running, the queue has been
             // initialized and cluster is healthy
-            ClusterManager clusterManager = new ClusterManagerImpl();
+            ClusterManager clusterManager = this.controller.clusterManager;
             boolean isClusterHealthy = clusterManager.isClusterHealthy();
             if(!isClusterHealthy) {
                 LOGGER.error("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
@@ -375,7 +374,7 @@ public class ExperimentManager implements Closeable {
 
             //if cluster is not healthy add error message to experimentStatus
             try {
-                ClusterManager clusterManager = new ClusterManagerImpl();
+                ClusterManager clusterManager = this.controller.clusterManager;
                 boolean isHealthy = clusterManager.isClusterHealthy();
                 if(!isHealthy) {
                     LOGGER.error("Cluster became unhealthy during the experiment! Some nodes are down." +
@@ -384,8 +383,6 @@ public class ExperimentManager implements Closeable {
 
                     experimentStatus.addError(HobbitErrors.ClusterNotHealthy);
                 }
-            } catch (DockerCertificateException e) {
-                LOGGER.error("Could not initialize clusterManager. ", e);
             } catch (DockerException e) {
                 LOGGER.error("Could not get cluster health status. ", e);
             } catch (InterruptedException e) {

--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -155,8 +155,10 @@ public class ExperimentManager implements Closeable {
             ClusterManager clusterManager = new ClusterManagerImpl();
             boolean isClusterHealthy = clusterManager.isClusterHealthy();
             if(!isClusterHealthy) {
-                throw new Exception("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
-                        "Check your cluster consistency or adjust SWARM_NODE_NUMBER environment variable.");
+                LOGGER.error("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
+                        "Check your cluster consistency or adjust SWARM_NODE_NUMBER environment variable." +
+                        "Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
+                        "Current number of nodes: "+clusterManager.getNumberOfNodes());
             }
             if ((experimentStatus == null) && (controller.queue != null) && (isClusterHealthy)) {
                 ExperimentConfiguration config = controller.queue.getNextExperiment();
@@ -376,6 +378,10 @@ public class ExperimentManager implements Closeable {
                 ClusterManager clusterManager = new ClusterManagerImpl();
                 boolean isHealthy = clusterManager.isClusterHealthy();
                 if(!isHealthy) {
+                    LOGGER.error("Cluster became unhealthy during the experiment! Some nodes are down.");
+                    LOGGER.error("Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
+                            "Current number of nodes: "+clusterManager.getNumberOfNodes());
+
                     experimentStatus.addError(HobbitErrors.ClusterNotHealthy);
                 }
             } catch (DockerCertificateException e) {

--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -157,8 +157,8 @@ public class ExperimentManager implements Closeable {
             if(!isClusterHealthy) {
                 LOGGER.error("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
                         "Check your cluster consistency or adjust SWARM_NODE_NUMBER environment variable." +
-                        "Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
-                        "Current number of nodes: "+clusterManager.getNumberOfNodes());
+                        " Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
+                        " Current number of nodes: "+clusterManager.getNumberOfNodes());
             }
             if ((experimentStatus == null) && (controller.queue != null) && (isClusterHealthy)) {
                 ExperimentConfiguration config = controller.queue.getNextExperiment();

--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -151,15 +151,16 @@ public class ExperimentManager implements Closeable {
         try {
             // if there is no benchmark running, the queue has been
             // initialized and cluster is healthy
-            ClusterManager clusterManager = this.controller.clusterManager;
-            boolean isClusterHealthy = clusterManager.isClusterHealthy();
-            if(!isClusterHealthy) {
-                LOGGER.error("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
-                        "Check your cluster consistency or adjust SWARM_NODE_NUMBER environment variable." +
-                        " Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
-                        " Current number of nodes: "+clusterManager.getNumberOfNodes());
-            }
-            if ((experimentStatus == null) && (controller.queue != null) && (isClusterHealthy)) {
+            if ((experimentStatus == null) && (controller.queue != null)) {
+                ClusterManager clusterManager = this.controller.clusterManager;
+                boolean isClusterHealthy = clusterManager.isClusterHealthy();
+                if(!isClusterHealthy) {
+                    LOGGER.error("Can not start next experiment in the queue, cluster is NOT HEALTHY. " +
+                                 "Check your cluster consistency or adjust SWARM_NODE_NUMBER environment variable." +
+                                 " Expected number of nodes: "+clusterManager.getExpectedNumberOfNodes()+
+                                 " Current number of nodes: "+clusterManager.getNumberOfNodes());
+                    return;
+                }
                 ExperimentConfiguration config = controller.queue.getNextExperiment();
                 LOGGER.debug("Trying to start the next benchmark.");
                 if (config == null) {

--- a/platform-controller/src/main/java/org/hobbit/controller/PlatformController.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/PlatformController.java
@@ -44,14 +44,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.hobbit.controller.analyze.ExperimentAnalyzer;
 import org.hobbit.controller.data.ExperimentConfiguration;
-import org.hobbit.controller.docker.ContainerManager;
-import org.hobbit.controller.docker.ContainerManagerImpl;
-import org.hobbit.controller.docker.ContainerStateObserver;
-import org.hobbit.controller.docker.ContainerStateObserverImpl;
-import org.hobbit.controller.docker.ContainerTerminationCallback;
-import org.hobbit.controller.docker.GitlabBasedImageManager;
-import org.hobbit.controller.docker.ImageManager;
-import org.hobbit.controller.docker.ResourceInformationCollector;
+import org.hobbit.controller.docker.*;
 import org.hobbit.controller.health.ClusterHealthChecker;
 import org.hobbit.controller.health.ClusterHealthCheckerImpl;
 import org.hobbit.controller.queue.ExperimentQueue;
@@ -164,6 +157,8 @@ public class PlatformController extends AbstractCommandReceivingComponent
 
     protected ResourceInformationCollector resInfoCollector;
 
+    protected ClusterManager clusterManager;
+
     /**
      * Timer used to trigger publishing of challenges
      */
@@ -213,6 +208,8 @@ public class PlatformController extends AbstractCommandReceivingComponent
         queue = new ExperimentQueueImpl();
 
         storage = StorageServiceClient.create(outgoingDataQueuefactory.getConnection());
+
+        clusterManager = new ClusterManagerImpl();
 
         // the experiment manager should be the last module to create since it
         // directly starts to use the other modules

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManager.java
@@ -1,0 +1,34 @@
+package org.hobbit.controller.docker;
+
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.Info;
+
+/**
+ * This interface is implemented by classes that can be used to manage and
+ * collect info about Docker Cluster.
+ *
+ * @author Ivan Ermilov (iermilov@informatik.uni-leipzig.de)
+ *
+ */
+public interface ClusterManager {
+    /**
+     * Get number of nodes in the cluster
+     *
+     * @return number of nodes
+     */
+    public Info getClusterInfo() throws DockerException, InterruptedException;
+
+    /**
+     * Get number of nodes in the cluster
+     *
+     * @return number of nodes
+     */
+    public Integer getNumberOfNodes() throws DockerException, InterruptedException;
+
+    /**
+     * Get the health status of the cluster
+     *
+     * @return boolean (is cluster healthy?)
+     */
+    public boolean isClusterHealthy() throws DockerException, InterruptedException;
+}

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManager.java
@@ -12,9 +12,9 @@ import com.spotify.docker.client.messages.Info;
  */
 public interface ClusterManager {
     /**
-     * Get number of nodes in the cluster
+     * Get cluster info
      *
-     * @return number of nodes
+     * @return com.spotify.docker.client.messages.Info
      */
     public Info getClusterInfo() throws DockerException, InterruptedException;
 
@@ -31,4 +31,12 @@ public interface ClusterManager {
      * @return boolean (is cluster healthy?)
      */
     public boolean isClusterHealthy() throws DockerException, InterruptedException;
+
+    /**
+     * Get expected number of nodes in the cluster
+     * Set externally by SWARM_NODE_NUMBER env variable
+     *
+     * @return expected number of nodes
+     */
+    public Integer getExpectedNumberOfNodes();
 }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
@@ -4,6 +4,9 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.Info;
+import org.hobbit.controller.ExperimentManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ClusterManager implementation
@@ -12,6 +15,8 @@ import com.spotify.docker.client.messages.Info;
  *
  */
 public class ClusterManagerImpl implements ClusterManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerImpl.class);
+
     /**
      * Docker client instance
      */
@@ -20,7 +25,7 @@ public class ClusterManagerImpl implements ClusterManager {
 
     public ClusterManagerImpl() throws DockerCertificateException {
         dockerClient = DockerUtility.getDockerClient();
-        expectedNumberOfNodes = Integer.getInteger(System.getenv("SWARM_NODE_NUMBER"));
+        expectedNumberOfNodes = Integer.parseInt(System.getenv("SWARM_NODE_NUMBER"));
         if(expectedNumberOfNodes == null) {
             expectedNumberOfNodes = 1;
         }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
@@ -22,12 +22,15 @@ public class ClusterManagerImpl implements ClusterManager {
      */
     private DockerClient dockerClient;
     private Integer expectedNumberOfNodes = 0;
+    private String SWARM_NODE_NUMBER = null;
 
     public ClusterManagerImpl() throws DockerCertificateException {
         dockerClient = DockerUtility.getDockerClient();
-        expectedNumberOfNodes = Integer.parseInt(System.getenv("SWARM_NODE_NUMBER"));
-        if(expectedNumberOfNodes == null) {
+        SWARM_NODE_NUMBER = System.getenv("SWARM_NODE_NUMBER");
+        if(SWARM_NODE_NUMBER == null) {
             expectedNumberOfNodes = 1;
+        } else {
+            expectedNumberOfNodes = Integer.parseInt(SWARM_NODE_NUMBER);
         }
     }
 

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
@@ -1,6 +1,7 @@
 package org.hobbit.controller.docker;
 
 import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.Info;
 
@@ -17,7 +18,7 @@ public class ClusterManagerImpl implements ClusterManager {
     private DockerClient dockerClient;
     private Integer expectedNumberOfNodes = 0;
 
-    public ClusterManagerImpl() throws Exception {
+    public ClusterManagerImpl() throws DockerCertificateException {
         dockerClient = DockerUtility.getDockerClient();
         expectedNumberOfNodes = Integer.getInteger(System.getenv("SWARM_NODE_NUMBER"));
         if(expectedNumberOfNodes == null) {
@@ -40,5 +41,9 @@ public class ClusterManagerImpl implements ClusterManager {
             return true;
         }
         return false;
+    }
+
+    public Integer getExpectedNumberOfNodes() {
+        return expectedNumberOfNodes;
     }
 }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ClusterManagerImpl.java
@@ -1,0 +1,44 @@
+package org.hobbit.controller.docker;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.Info;
+
+/**
+ * ClusterManager implementation
+ *
+ * @author Ivan Ermilov (iermilov@informatik.uni-leipzig.de)
+ *
+ */
+public class ClusterManagerImpl implements ClusterManager {
+    /**
+     * Docker client instance
+     */
+    private DockerClient dockerClient;
+    private Integer expectedNumberOfNodes = 0;
+
+    public ClusterManagerImpl() throws Exception {
+        dockerClient = DockerUtility.getDockerClient();
+        expectedNumberOfNodes = Integer.getInteger(System.getenv("SWARM_NODE_NUMBER"));
+        if(expectedNumberOfNodes == null) {
+            expectedNumberOfNodes = 1;
+        }
+    }
+
+    public Info getClusterInfo() throws DockerException, InterruptedException {
+        return dockerClient.info();
+    }
+
+    public Integer getNumberOfNodes() throws DockerException, InterruptedException {
+        final Info info = getClusterInfo();
+        return info.swarm().nodes();
+    }
+
+    public boolean isClusterHealthy() throws DockerException, InterruptedException {
+        Integer numberOfNodes = getNumberOfNodes();
+        if(numberOfNodes >= expectedNumberOfNodes) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -154,10 +154,7 @@ public class ContainerManagerImpl implements ContainerManager {
      */
     public ContainerManagerImpl() throws Exception {
         LOGGER.info("Deployed as \"{}\".", DEPLOY_ENV);
-        Builder builder = DefaultDockerClient.fromEnv();
-        builder.connectionPoolSize(5000);
-        builder.connectTimeoutMillis(1000);
-        dockerClient = builder.build();
+        dockerClient = DockerUtility.getDockerClient();
 
         String username = System.getenv(USER_NAME_KEY);
         String email = System.getenv(USER_EMAIL_KEY);

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
@@ -1,0 +1,13 @@
+package org.hobbit.controller.docker;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+
+public static class DockerUtility {
+    public static DockerClient getDockerClient() {
+        DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
+        builder.connectionPoolSize(5000);
+        builder.connectTimeoutMillis(1000);
+        return builder.build();
+    }
+}

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
@@ -2,9 +2,10 @@ package org.hobbit.controller.docker;
 
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
 
-public static class DockerUtility {
-    public static DockerClient getDockerClient() {
+public class DockerUtility {
+    public static DockerClient getDockerClient() throws DockerCertificateException {
         DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
         builder.connectionPoolSize(5000);
         builder.connectTimeoutMillis(1000);

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
@@ -11,7 +11,7 @@ public class DockerUtility {
         // Exists only to defeat instantiation.
     }
 
-    public static DockerClient getDockerClient() throws DockerCertificateException {
+    public static synchronized DockerClient getDockerClient() throws DockerCertificateException {
         if(dockerClient == null) {
             dockerClient = initializeDockerClient();
         }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/DockerUtility.java
@@ -5,7 +5,20 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 
 public class DockerUtility {
+    private static DockerClient dockerClient = null;
+
+    protected DockerUtility() {
+        // Exists only to defeat instantiation.
+    }
+
     public static DockerClient getDockerClient() throws DockerCertificateException {
+        if(dockerClient == null) {
+            dockerClient = initializeDockerClient();
+        }
+        return dockerClient;
+    }
+
+    public static DockerClient initializeDockerClient() throws DockerCertificateException {
         DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv();
         builder.connectionPoolSize(5000);
         builder.connectTimeoutMillis(1000);

--- a/platform-controller/src/test/java/org/hobbit/controller/ExperimentTimeoutTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/ExperimentTimeoutTest.java
@@ -6,14 +6,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
+import com.spotify.docker.client.exceptions.DockerCertificateException;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.hobbit.controller.data.ExperimentConfiguration;
-import org.hobbit.controller.docker.ContainerManager;
-import org.hobbit.controller.docker.ContainerStateObserver;
-import org.hobbit.controller.docker.ContainerTerminationCallback;
-import org.hobbit.controller.docker.ImageManager;
+import org.hobbit.controller.docker.*;
 import org.hobbit.controller.queue.InMemoryQueue;
 import org.hobbit.core.data.BenchmarkMetaData;
 import org.hobbit.core.data.SystemMetaData;
@@ -94,6 +92,11 @@ public class ExperimentTimeoutTest {
             containerManager = new DummyContainerManager(benchmarkControllerTerminated, this);
             queue = new InMemoryQueue();
             storage = new DummyStorageServiceClient();
+            try {
+                clusterManager = new ClusterManagerImpl();
+            } catch (DockerCertificateException e) {
+                e.printStackTrace();
+            }
         }
 
         @Override

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ClusterManagerImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ClusterManagerImplTest.java
@@ -1,0 +1,37 @@
+package org.hobbit.controller.docker;
+
+import com.spotify.docker.client.messages.Info;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ClusterManagerImplTest {
+
+    ClusterManagerImpl clusterManager = null;
+
+    @Before
+    public void setUp() throws Exception {
+        clusterManager = new ClusterManagerImpl();
+    }
+
+    @Test
+    public void getClusterInfo() throws Exception {
+        final Info info = clusterManager.getClusterInfo();
+        assertNotNull(info);
+    }
+
+    @Test
+    public void getNumberOfNodes() throws Exception {
+        Integer numberOfNodes = clusterManager.getNumberOfNodes();
+        assertTrue(numberOfNodes == 1);
+    }
+
+    @Test
+    public void isClusterHealthy() throws Exception {
+        boolean isHealthy = clusterManager.isClusterHealthy();
+        assertTrue(isHealthy);
+    }
+
+
+}


### PR DESCRIPTION
Implements features necessary described in #97:
* before starting next experiment check if cluster is healthy
* if cluster is not healthy display ERROR message with expected/current number of nodes
* if cluster become unhealthy during experiment, add ClusterNotHealthy error to the result model