### PR TITLE
Hotfix image pull waiting 243

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
-  - sudo apt-get -y install docker-ce
+  - sudo apt-get -y install docker-ce=17.12.1~ce-0~ubuntu
   - nvm install --lts node
   - docker swarm init
   - docker network create -d overlay --attachable hobbit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - sudo apt-get -y install docker-ce
   - nvm install --lts node
   - docker swarm init
+  - docker network create -d overlay --attachable hobbit
 language: java
 script:
   - make test

--- a/platform-controller/Makefile
+++ b/platform-controller/Makefile
@@ -21,6 +21,10 @@ test: deps
 	PROMETHEUS_HOST=localhost \
 	mvn --update-snapshots clean test
 
+test-single:
+	docker rmi busybox
+	mvn --update-snapshots clean test -Dtest=org.hobbit.controller.docker.ContainerManagerImplTest#startContainer
+
 test-all: test
 
 deps: redis rabbit node-exporter cAdvisor prometheus

--- a/platform-controller/pom.xml
+++ b/platform-controller/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.9.2</version>
+            <version>8.11.2</version>
         </dependency>
         <!-- JSON lib -->
         <dependency>
@@ -132,6 +132,17 @@
         </dependency>
         <!-- ~~~~~~~~~~~~~~~~~~~ End Testing ~~~~~~~~~~~~~~~~~~~~~~ -->
     </dependencies>
+    
+    <dependencyManagement>
+        <dependencies>
+            <!-- Necessary to force Maven to choose the latest jackson version -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.9.4</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.hobbit.controller.gitlab.GitlabControllerImpl;
+import org.hobbit.controller.utils.Waiting;
 import org.hobbit.core.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +86,9 @@ public class ContainerManagerImpl implements ContainerManager {
             ? System.getenv().get(DOCKER_AUTOPULL_ENV_KEY) == "1"
             : true;
 
+    private static final long DOCKER_POLL_INTERVAL = 100;
+    private static final long DOCKER_IMAGE_PULL_MAX_WAITING_TIME = 1200000; // 20 min
+
     /**
      * Default network for new containers
      */
@@ -96,30 +100,17 @@ public class ContainerManagerImpl implements ContainerManager {
     /**
      * Task states which are considered as not running yet.
      */
-    public static final Set<String> NEW_TASKS_STATES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] {
-        TaskStatus.TASK_STATE_NEW,
-        TaskStatus.TASK_STATE_ALLOCATED,
-        TaskStatus.TASK_STATE_PENDING,
-        TaskStatus.TASK_STATE_ASSIGNED,
-        TaskStatus.TASK_STATE_ACCEPTED,
-        TaskStatus.TASK_STATE_PREPARING,
-        TaskStatus.TASK_STATE_READY,
-        TaskStatus.TASK_STATE_STARTING,
-    })));
+    public static final Set<String> NEW_TASKS_STATES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(new String[] { TaskStatus.TASK_STATE_NEW, TaskStatus.TASK_STATE_ALLOCATED,
+                    TaskStatus.TASK_STATE_PENDING, TaskStatus.TASK_STATE_ASSIGNED, TaskStatus.TASK_STATE_ACCEPTED,
+                    TaskStatus.TASK_STATE_PREPARING, TaskStatus.TASK_STATE_READY, TaskStatus.TASK_STATE_STARTING, })));
     /**
      * Task states which are considered as not finished yet.
      */
-    public static final Set<String> UNFINISHED_TASK_STATES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] {
-        TaskStatus.TASK_STATE_NEW,
-        TaskStatus.TASK_STATE_ALLOCATED,
-        TaskStatus.TASK_STATE_PENDING,
-        TaskStatus.TASK_STATE_ASSIGNED,
-        TaskStatus.TASK_STATE_ACCEPTED,
-        TaskStatus.TASK_STATE_PREPARING,
-        TaskStatus.TASK_STATE_READY,
-        TaskStatus.TASK_STATE_STARTING,
-        TaskStatus.TASK_STATE_RUNNING,
-    })));
+    public static final Set<String> UNFINISHED_TASK_STATES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            new String[] { TaskStatus.TASK_STATE_NEW, TaskStatus.TASK_STATE_ALLOCATED, TaskStatus.TASK_STATE_PENDING,
+                    TaskStatus.TASK_STATE_ASSIGNED, TaskStatus.TASK_STATE_ACCEPTED, TaskStatus.TASK_STATE_PREPARING,
+                    TaskStatus.TASK_STATE_READY, TaskStatus.TASK_STATE_STARTING, TaskStatus.TASK_STATE_RUNNING, })));
     /**
      * Logging separator for type/experiment id.
      */
@@ -133,10 +124,9 @@ public class ContainerManagerImpl implements ContainerManager {
      */
     private final RegistryAuth gitlabAuth;
     /**
-     * Empty authentication configuration.
-     * Docker client's createService() uses ConfigFileRegistryAuthSupplier by default
-     * (if auth is omitted)
-     * and warns about not being able to use it with swarm each time.
+     * Empty authentication configuration. Docker client's createService() uses
+     * ConfigFileRegistryAuthSupplier by default (if auth is omitted) and warns
+     * about not being able to use it with swarm each time.
      */
     private final RegistryAuth nullAuth = RegistryAuth.builder().build();
     /**
@@ -186,7 +176,8 @@ public class ContainerManagerImpl implements ContainerManager {
         // if not found - create new one
         if (hobbitNetwork == null) {
             LOGGER.warn("Could not find hobbit docker network, creating a new one");
-            final NetworkConfig networkConfig = NetworkConfig.builder().name(HOBBIT_DOCKER_NETWORK).driver("overlay").build();
+            final NetworkConfig networkConfig = NetworkConfig.builder().name(HOBBIT_DOCKER_NETWORK).driver("overlay")
+                    .build();
             dockerClient.createNetwork(networkConfig);
         }
     }
@@ -219,18 +210,6 @@ public class ContainerManagerImpl implements ContainerManager {
         builder.append('-');
         builder.append(uuid);
         return builder.toString();
-    }
-
-    @FunctionalInterface
-    private interface ExceptionBooleanSupplier {
-        boolean getAsBoolean() throws Exception;
-    }
-
-    private static void waitFor(ExceptionBooleanSupplier checkSupplier, long interval) throws Exception {
-        while (!checkSupplier.getAsBoolean()) {
-            // TODO: can use some kind of inverval adjustion
-            Thread.sleep(interval);
-        }
     }
 
     /**
@@ -305,9 +284,10 @@ public class ContainerManagerImpl implements ContainerManager {
             taskCfgBuilder.logDriver(Driver.builder().name(LOGGING_DRIVER_GELF).options(logOptions).build());
         }
 
-        // hello-world image used in tests (so we can safely remove all containers depending on it)
+        // hello-world image used in tests (so we can safely remove all containers
+        // depending on it)
         // and it does not have anything besides "/hello" executable
-        String[] command = imageName.equals("hello-world") ? new String[]{ "/hello" } : new String[]{  "true" };
+        String[] command = imageName.equals("hello-world") ? new String[] { "/hello" } : new String[] { "true" };
         cfgBuilder.command(command);
 
         ContainerSpec cfg = cfgBuilder.build();
@@ -334,34 +314,42 @@ public class ContainerManagerImpl implements ContainerManager {
             }
             String serviceId = resp.id();
 
+            // create a set to collect the tasks of nodes that have finished the pulling
+            final Set<String> finshedTaskIds = Collections.synchronizedSet(new HashSet<String>());
+
             // wait for any container of that service to start on each node
-            waitFor(() -> {
-                List<Task> pullingTasks = dockerClient.listTasks(Task.Criteria.builder().serviceName(serviceId).build());
-                if (pullingTasks.size() < totalNodes) {
-                    return false;
-                }
-                for (Task pullingTask : pullingTasks) {
-                    String state = pullingTask.status().state();
-                    if (UNFINISHED_TASK_STATES.contains(state)) {
+            try {
+                Waiting.waitFor(() -> {
+                    List<Task> pullingTasks = dockerClient
+                            .listTasks(Task.Criteria.builder().serviceName(serviceId).build());
+                    for (Task pullingTask : pullingTasks) {
+                        String state = pullingTask.status().state();
+                        if (!UNFINISHED_TASK_STATES.contains(state)) {
+                            if (state.equals(TaskStatus.TASK_STATE_REJECTED)) {
+                                LOGGER.error("Couldn't pull image {} on node {}. {}", imageName, pullingTask.nodeId(),
+                                        pullingTask.status().err());
+                                throw new Exception("Couldn't pull image on node " + pullingTask.nodeId() + ".");
+                            }
+                            finshedTaskIds.add(pullingTask.id());
+                        }
+                    }
+                    if (finshedTaskIds.size() >= totalNodes) {
+                        LOGGER.info("Swarm pulled image '{}' ({})", imageName,
+                                pullingTasks.stream().map(t -> t.status().state()).collect(Collectors.joining(", ")));
+                        return true;
+                    } else {
                         return false;
                     }
-
-                    if (state.equals(TaskStatus.TASK_STATE_REJECTED)) {
-                        LOGGER.error("Couldn't pull image {} on node {}. {}", imageName, pullingTask.nodeId(), pullingTask.status().err());
-                        throw new Exception("Couldn't pull image on node " + pullingTask.nodeId() + ".");
-                    }
-                }
-
-                LOGGER.info("Swarm pulled image '{}' ({})", imageName,
-                        pullingTasks.stream().map(t -> t.status().state()).collect(Collectors.joining(", ")));
-
-                return true;
-            }, 100);
+                }, DOCKER_POLL_INTERVAL, DOCKER_IMAGE_PULL_MAX_WAITING_TIME);
+            } catch (InterruptedException e) {
+                LOGGER.warn(
+                        "Interrupted while waiting for the image {} to be pulled. Assuming that pulling was successful. Exception: {}",
+                        imageName, e.getLocalizedMessage());
+            }
 
             dockerClient.removeService(serviceId);
         } catch (Exception e) {
-            LOGGER.error("Exception while pulling the image \"" + imageName + "\". " + e.getClass().getName() + ": "
-                    + e.getLocalizedMessage());
+            LOGGER.error("Exception while pulling the image \"" + imageName + "\".", e);
         }
     }
 
@@ -428,7 +416,8 @@ public class ContainerManagerImpl implements ContainerManager {
             ClusterManager clusterManager = new ClusterManagerImpl();
             numberOfSwarmNodes = clusterManager.getNumberOfNodes();
         } catch (DockerCertificateException e) {
-            LOGGER.error("Could not initialize Cluster Manager, will use container placement constraints by default. ", e);
+            LOGGER.error("Could not initialize Cluster Manager, will use container placement constraints by default. ",
+                    e);
         } catch (Exception e) {
             LOGGER.error("Could not get number of swarm nodes. ", e);
         }
@@ -437,48 +426,30 @@ public class ContainerManagerImpl implements ContainerManager {
             if ((((parentType == null) || Constants.CONTAINER_TYPE_BENCHMARK.equals(parentType))
                     && Constants.CONTAINER_TYPE_SYSTEM.equals(containerType))
                     || Constants.CONTAINER_TYPE_SYSTEM.equals(parentType)) {
-                taskCfgBuilder.placement(
-                        Placement.create(
-                                new ArrayList<String>(
-                                        Arrays.asList("node.labels.org.hobbit.workergroup==system")
-                                )
-                        )
-                );
+                taskCfgBuilder.placement(Placement
+                        .create(new ArrayList<String>(Arrays.asList("node.labels.org.hobbit.workergroup==system"))));
                 containerType = Constants.CONTAINER_TYPE_SYSTEM;
             } else if (Constants.CONTAINER_TYPE_DATABASE.equals(containerType)
                     && ((parentType == null) || Constants.CONTAINER_TYPE_BENCHMARK.equals(parentType)
-                    || Constants.CONTAINER_TYPE_DATABASE.equals(parentType))) {
+                            || Constants.CONTAINER_TYPE_DATABASE.equals(parentType))) {
                 // defaultEnv.add("constraint:org.hobbit.workergroup==" +
                 // Constants.CONTAINER_TYPE_DATABASE);
                 // defaultEnv.add("constraint:org.hobbit.type==data");
                 // database containers have to be deployed on the benchmark nodes (see
                 // https://github.com/hobbit-project/platform/issues/170)
-                taskCfgBuilder.placement(
-                        Placement.create(
-                                new ArrayList<String>(
-                                        Arrays.asList("node.labels.org.hobbit.workergroup==benchmark")
-                                )
-                        )
-                );
+                taskCfgBuilder.placement(Placement
+                        .create(new ArrayList<String>(Arrays.asList("node.labels.org.hobbit.workergroup==benchmark"))));
             } else if (Constants.CONTAINER_TYPE_BENCHMARK.equals(containerType)
                     && ((parentType == null) || Constants.CONTAINER_TYPE_BENCHMARK.equals(parentType))) {
-                taskCfgBuilder.placement(
-                        Placement.create(
-                                new ArrayList<String>(
-                                        Arrays.asList("node.labels.org.hobbit.workergroup==benchmark")
-                                )
-                        )
-                );
+                taskCfgBuilder.placement(Placement
+                        .create(new ArrayList<String>(Arrays.asList("node.labels.org.hobbit.workergroup==benchmark"))));
             } else {
-                LOGGER.error(
-                        "Got a request to create a container with type={} and parentType={}. " +
-                                "Got no rule to determine its type. Returning null.",
-                        containerType, parentType);
+                LOGGER.error("Got a request to create a container with type={} and parentType={}. "
+                        + "Got no rule to determine its type. Returning null.", containerType, parentType);
                 return null;
             }
         } else {
-            LOGGER.warn(
-                    "The swarm cluster got only 1 node, I will not use placement constraints.");
+            LOGGER.warn("The swarm cluster got only 1 node, I will not use placement constraints.");
         }
 
         // create env vars to pass
@@ -528,11 +499,11 @@ public class ContainerManagerImpl implements ContainerManager {
             String containerId = resp.id();
             // wait for a container of that service to start
             List<Task> serviceTasks = new ArrayList<Task>();
-            waitFor(() -> {
+            Waiting.waitFor(() -> {
                 serviceTasks.clear();
                 serviceTasks.addAll(dockerClient.listTasks(Task.Criteria.builder().serviceName(containerId).build()));
                 return !serviceTasks.isEmpty() && !NEW_TASKS_STATES.contains(serviceTasks.get(0).status().state());
-            }, 100);
+            }, DOCKER_POLL_INTERVAL);
             String taskId = serviceTasks.get(0).id();
             // return new container id
             return taskId;
@@ -578,11 +549,10 @@ public class ContainerManagerImpl implements ContainerManager {
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
-                                 String[] command, String experimentId) {
+            String[] command, String experimentId) {
         this.experimentId = experimentId;
         return startContainer(imageName, containerType, parentId, env, command);
     }
-
 
     @Override
     public void removeContainer(String taskId) {
@@ -595,26 +565,26 @@ public class ContainerManagerImpl implements ContainerManager {
                 LOGGER.warn("Container for task {} has no exit code, assuming 0", taskId);
                 exitCode = 0;
             }
-            if(DEPLOY_ENV.equals(DEPLOY_ENV_DEVELOP)) {
-                LOGGER.info("Will not remove container with task id {}. " +
-                        "Development mode is enabled.", taskId);
-            } else if(DEPLOY_ENV.equals(DEPLOY_ENV_TESTING) && (exitCode != 0)) {
+            if (DEPLOY_ENV.equals(DEPLOY_ENV_DEVELOP)) {
+                LOGGER.info("Will not remove container with task id {}. " + "Development mode is enabled.", taskId);
+            } else if (DEPLOY_ENV.equals(DEPLOY_ENV_TESTING) && (exitCode != 0)) {
                 // In testing - do not remove containers if they returned non-zero exit code
-                LOGGER.info("Will not remove container with task id {}. " +
-                        "ExitCode != 0 and testing mode is enabled.", taskId);
+                LOGGER.info(
+                        "Will not remove container with task id {}. " + "ExitCode != 0 and testing mode is enabled.",
+                        taskId);
             } else {
                 LOGGER.info("Removing service of container with task id {}. ", taskId);
                 dockerClient.removeService(serviceId);
 
                 // wait for the service to disappear
-                waitFor(() -> {
+                Waiting.waitFor(() -> {
                     try {
                         dockerClient.inspectService(serviceId);
                         return false;
                     } catch (ServiceNotFoundException e) {
                         return true;
                     }
-                }, 100);
+                }, DOCKER_POLL_INTERVAL);
             }
         } catch (TaskNotFoundException | ServiceNotFoundException e) {
             LOGGER.error("Couldn't remove container {} because it doesn't exist", taskId);

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -329,7 +329,7 @@ public class ContainerManagerImpl implements ContainerManager {
                             if (state.equals(TaskStatus.TASK_STATE_REJECTED)) {
                                 LOGGER.error("Couldn't pull image {} on node {}. {}", imageName, pullingTask.nodeId(),
                                         pullingTask.status().err());
-                                throw new Exception("Couldn't pull image on node " + pullingTask.nodeId() + ".");
+                                throw new Exception("Couldn't pull image on node " + pullingTask.nodeId() + ": " + pullingTask.status().err());
                             }
                             finshedTaskIds.add(pullingTask.id());
                         }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -510,7 +510,7 @@ public class ContainerManagerImpl implements ContainerManager {
                     TaskStatus status = serviceTasks.get(0).status();
                     if (status.state().equals(TaskStatus.TASK_STATE_PENDING)) {
                         LOGGER.info("[" + status.err() + "]");
-                        if (status.err().matches("no suitable node.*")) {
+                        if (status.err() != null && status.err().matches("no suitable node.*")) {
                             throw new Exception(status.err());
                         }
                     }

--- a/platform-controller/src/main/java/org/hobbit/controller/utils/ExceptionBooleanSupplier.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/utils/ExceptionBooleanSupplier.java
@@ -1,0 +1,23 @@
+package org.hobbit.controller.utils;
+
+/**
+ * A simple functional interface can be used to implement a function that
+ * returns a boolean but is allowed to throw an {@link Exception}.
+ * 
+ * @author Denis Kuchelev
+ * @author Michael R&ouml;der (michael.roeder@uni-paderborn.de)
+ *
+ */
+@FunctionalInterface
+public interface ExceptionBooleanSupplier {
+    /**
+     * Method that can be used to implement a function that returns a boolean but is
+     * allowed to throw an {@link Exception}.
+     * 
+     * @return a boolean value.
+     * @throws Exception
+     *             if the internal check causes an error that can not be handled by
+     *             the method itself.
+     */
+    boolean getAsBoolean() throws Exception;
+}

--- a/platform-controller/src/main/java/org/hobbit/controller/utils/Waiting.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/utils/Waiting.java
@@ -1,0 +1,57 @@
+package org.hobbit.controller.utils;
+
+/**
+ * A simple class easing the waiting for a given check function to return
+ * {@code true}.
+ * 
+ * @author Denis Kuchelev
+ * @author Michael R&ouml;der (michael.roeder@uni-paderborn.de)
+ *
+ */
+public class Waiting {
+
+    /**
+     * Waits until the given function returns {@code true} while executing
+     * repeatedly after the given amount of time.
+     * 
+     * @param checkSupplier
+     *            the function for which this method is waiting for to return
+     *            {@code true}.
+     * @param interval
+     *            the time interval in which the given function will be executed,
+     *            again (in ms).
+     * @throws Exception
+     *             every exception that might be thrown by the given function.
+     */
+    public static void waitFor(ExceptionBooleanSupplier checkSupplier, long interval) throws Exception {
+        waitFor(checkSupplier, interval, Long.MAX_VALUE);
+    }
+
+    /**
+     * Waits until the given function returns {@code true} while executing
+     * repeatedly after the given amount of time or terminates with throwing an
+     * {@link InterruptedException} when the given maximum waiting time has been
+     * reached.
+     * 
+     * @param checkSupplier
+     *            the function for which this method is waiting for to return
+     *            {@code true}.
+     * @param interval
+     *            the time interval in which the given function will be executed,
+     *            again (in ms).
+     * @throws InterruptedException
+     *             if the given maximum waiting time has been reached.
+     * @throws Exception
+     *             every exception that might be thrown by the given function.
+     */
+    public static void waitFor(ExceptionBooleanSupplier checkSupplier, long interval, long maxWaitingTime)
+            throws Exception {
+        long startTime = System.currentTimeMillis();
+        while (!checkSupplier.getAsBoolean()) {
+            if ((System.currentTimeMillis() - startTime) > maxWaitingTime) {
+                throw new InterruptedException("Interrupting waiting after reaching the maximum time to wait.");
+            }
+            Thread.sleep(interval);
+        }
+    }
+}

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerStateObserverImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerStateObserverImplTest.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.Semaphore;
 
@@ -51,8 +52,10 @@ public class ContainerStateObserverImplTest extends ContainerManagerBasedTest {
         // create two containers
         LOGGER.info("Creating container one...");
         String containerOneId = manager.startContainer("busybox:latest", Constants.CONTAINER_TYPE_SYSTEM, null, sleepCommand);
+        assertNotNull(containerOneId);
         LOGGER.info("Creating container two...");
         String containerTwoId = manager.startContainer("busybox:latest", Constants.CONTAINER_TYPE_SYSTEM, null, sleepCommand);
+        assertNotNull(containerTwoId);
 
         // add containers to observer
         observer.addObservedContainer(containerOneId);

--- a/platform-controller/src/test/java/org/hobbit/controller/utils/WaitingTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/utils/WaitingTest.java
@@ -1,0 +1,48 @@
+package org.hobbit.controller.utils;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class WaitingTest {
+
+    @Test(timeout = 10000)
+    public void testWaiting() throws Exception {
+        long checkInterval = 100;
+        final long startTime = System.currentTimeMillis();
+        // wait for 1 second
+        final long waitingTime = 1000;
+
+        Waiting.waitFor(() -> (System.currentTimeMillis() - startTime) >= waitingTime, checkInterval);
+        // Make sure that the method was really waiting
+        Assert.assertTrue((System.currentTimeMillis() - startTime) >= waitingTime);
+
+        // Define a max waiting time and update the start time
+        final long startTime2 = System.currentTimeMillis();
+        long maxWaitingTime = 1000000;
+        // maxWaitingTime > timeout, i.e., if the method is waiting too long, the test
+        // will fail.
+
+        Waiting.waitFor(() -> (System.currentTimeMillis() - startTime2) >= waitingTime, checkInterval, maxWaitingTime);
+        // Make sure that the method was really waiting
+        Assert.assertTrue((System.currentTimeMillis() - startTime2) >= waitingTime);
+    }
+
+    @Test(timeout = 10000)
+    public void testMaxWaiting() throws Exception {
+        long checkInterval = 100;
+        long startTime = System.currentTimeMillis();
+        // Define a waiting time which is too long for this test. If the maximum waiting
+        // time is not working, this test will fail because of its timeout.
+        long waitingTime = 100000;
+        long maxWaitingTime = 1000;
+
+        try {
+            Waiting.waitFor(() -> (System.currentTimeMillis() - startTime) >= waitingTime, checkInterval,
+                    maxWaitingTime);
+            Assert.fail();
+        } catch (InterruptedException e) {
+            // Every other exception will let the test fail
+        }
+    }
+}


### PR DESCRIPTION
Empty error was the reason for exceptions in most of the cases and prevented services to be deleted. I added check for empty error.

IMPORTANT: we have to use 17.12-ce-1, because in 18.03 the API was changed!!! Rollback your dev machine to 17.12-ce-1. We should not update the docker version on the servers.