### PR TITLE
Fix timeout values and comments in default config

### DIFF
--- a/platform-controller/src/main/resources/config.yaml
+++ b/platform-controller/src/main/resources/config.yaml
@@ -1,4 +1,4 @@
 timeouts:
   'http://my.test.benchmark': # benchmark URL
-    benchmark: 1200 # in seconds
-    challenge: 1200 # in seconds
+    benchmark: 1200000 # in ms
+    challenge: 1200000 # in ms


### PR DESCRIPTION
Actually it should be in milliseconds.

No further changes required - other code and production config got that right.