### PR TITLE
Hotfix challenge update restriction

### DIFF
--- a/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rabbitmq/RdfModelCreationHelper.java
+++ b/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rabbitmq/RdfModelCreationHelper.java
@@ -406,12 +406,13 @@ public class RdfModelCreationHelper {
         model.remove(model.listStatements(challenge, null, (RDFNode) null).toList().stream()
                 .filter(s -> !CHALLENGE_MODEL_PREDICATES.contains(s.getPredicate().getURI()))
                 .collect(Collectors.toList()));
-        // XXX TEMPORARILY: remove all KPISeq information
+        // Go through all tasks
         ResIterator taskIterator = model.listSubjectsWithProperty(HOBBIT.isTaskOf, challenge);
         Resource task;
         List<Statement> stmtsToRemove = new ArrayList<Statement>();
         while (taskIterator.hasNext()) {
             task = taskIterator.next();
+            // XXX TEMPORARILY: remove all KPISeq information
             List<Statement> temp = model.listStatements(task, HOBBIT.rankingKPIs, (RDFNode) null).toList();
             stmtsToRemove.addAll(temp);
             for (Statement s : temp) {
@@ -420,6 +421,9 @@ public class RdfModelCreationHelper {
                             .addAll(model.listStatements(s.getObject().asResource(), null, (RDFNode) null).toList());
                 }
             }
+            // Remove all registration information since they are handled by a different method
+            stmtsToRemove.addAll(model.listStatements(task, HOBBIT.involvesSystemInstance, (RDFNode) null).toList());
         }
+        model.remove(stmtsToRemove);
     }
 }

--- a/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rabbitmq/RdfModelCreationHelper.java
+++ b/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rabbitmq/RdfModelCreationHelper.java
@@ -18,8 +18,13 @@ package de.usu.research.hobbit.gui.rabbitmq;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -27,8 +32,11 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Seq;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
@@ -61,6 +69,11 @@ public class RdfModelCreationHelper {
     public static final String KPI_SEQ_APPENDIX = "_KPIs";
 
     public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("GMT");
+
+    private static final Set<String> CHALLENGE_MODEL_PREDICATES = new HashSet<String>(
+            Arrays.asList(RDF.type.toString(), RDFS.label.toString(), RDFS.comment.toString(), FOAF.homepage.toString(),
+                    HOBBIT.organizer.toString(), HOBBIT.executionDate.toString(), HOBBIT.publicationDate.toString(),
+                    HOBBIT.visible.toString(), HOBBIT.closed.toString()));
 
     /**
      * Creates a new RDF model with some predefined prefixes.
@@ -111,7 +124,7 @@ public class RdfModelCreationHelper {
         if (challenge.getHomepage() != null) {
             String challengeHomepage = challenge.getHomepage();
             // If the homepage does not start with http:// or https://
-            if((!challengeHomepage.startsWith("http://")) && (!challengeHomepage.startsWith("https://"))) {
+            if ((!challengeHomepage.startsWith("http://")) && (!challengeHomepage.startsWith("https://"))) {
                 challengeHomepage = "http://" + challengeHomepage;
             }
             try {
@@ -377,5 +390,36 @@ public class RdfModelCreationHelper {
         // XSDDatatype.XSDdateTime);
         String str = date.format(DateTimeFormatter.ISO_DATE_TIME);
         return model.createTypedLiteral(XSDDatatype.XSDdateTime.parseValidated(str), XSDDatatype.XSDdateTime);
+    }
+
+    /**
+     * This method removes all triples from the given model which can not be
+     * represented as bean. It is necessary to do that before comparing two RDF
+     * models with each other if one of the has been created from a challenge bean
+     * using {@link #addChallenge(ChallengeBean, Model)}.
+     * 
+     * @param model
+     */
+    public static void reduceModelToChallenge(Model model, Resource challenge) {
+        // remove all statements that have the challenge as subject but not one of the
+        // allowed predicates
+        model.remove(model.listStatements(challenge, null, (RDFNode) null).toList().stream()
+                .filter(s -> !CHALLENGE_MODEL_PREDICATES.contains(s.getPredicate().getURI()))
+                .collect(Collectors.toList()));
+        // XXX TEMPORARILY: remove all KPISeq information
+        ResIterator taskIterator = model.listSubjectsWithProperty(HOBBIT.isTaskOf, challenge);
+        Resource task;
+        List<Statement> stmtsToRemove = new ArrayList<Statement>();
+        while (taskIterator.hasNext()) {
+            task = taskIterator.next();
+            List<Statement> temp = model.listStatements(task, HOBBIT.rankingKPIs, (RDFNode) null).toList();
+            stmtsToRemove.addAll(temp);
+            for (Statement s : temp) {
+                if (s.getObject().isResource()) {
+                    stmtsToRemove
+                            .addAll(model.listStatements(s.getObject().asResource(), null, (RDFNode) null).toList());
+                }
+            }
+        }
     }
 }

--- a/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ChallengesResources.java
+++ b/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ChallengesResources.java
@@ -96,13 +96,14 @@ public class ChallengesResources {
                 list.addAll(challenges.stream().filter(ChallengeBean::isVisible).collect(Collectors.toList()));
             }
         }
-        return Response.ok(new GenericEntity<List<ChallengeBean>>(list){}).build();
+        return Response.ok(new GenericEntity<List<ChallengeBean>>(list) {
+        }).build();
     }
 
     /**
      * Adds benchmark and system labels and descriptions to the given challenge
-     * bean. The given user info is used to check the access of the user
-     * regarding this information.
+     * bean. The given user info is used to check the access of the user regarding
+     * this information.
      *
      * @param challenge
      *            the challenge bean that should be updated with the retrieved
@@ -110,8 +111,7 @@ public class ChallengesResources {
      * @param userInfo
      *            the information about the requesting user
      * @throws Exception
-     *             if the communication with the platform controller does not
-     *             work
+     *             if the communication with the platform controller does not work
      */
     @Deprecated
     protected void addInfoFromController(ChallengeBean challenge, UserInfoBean userInfo) throws Exception {
@@ -141,7 +141,8 @@ public class ChallengesResources {
         ChallengeBean bean = ChallengesResources.getChallenge(id, sc);
         if (bean != null)
             return Response.ok(bean).build();
-        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found")).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found"))
+                .build();
     }
 
     static ChallengeBean getChallenge(String id, SecurityContext sc) {
@@ -211,7 +212,8 @@ public class ChallengesResources {
                     return Response.ok(InfoBean.withMessage("Challenge was already closed")).build();
                 }
             } else {
-                return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found")).build();
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(InfoBean.withMessage("Challenge " + id + " not found")).build();
             }
         } else {
             PlatformControllerClient client = PlatformControllerClientSingleton.getInstance();
@@ -219,12 +221,13 @@ public class ChallengesResources {
                 try {
                     client.closeChallenge(id);
                     return Response.ok(InfoBean.withMessage("Challenge has been closed")).build();
-                }
-                catch (IOException ex) {
-                    return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(InfoBean.withMessage(ex.getMessage())).build();
+                } catch (IOException ex) {
+                    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity(InfoBean.withMessage(ex.getMessage())).build();
                 }
             } else {
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(InfoBean.withMessage("Couldn't get platform controller client.")).build();
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(InfoBean.withMessage("Couldn't get platform controller client.")).build();
             }
         }
     }
@@ -240,7 +243,7 @@ public class ChallengesResources {
         if (Application.isUsingDevDb()) {
             String updatedId = getDevDb().updateChallenge(challenge);
             if (updatedId != null) {
-                return Response.ok(new IdBean(updatedId)).build() ;
+                return Response.ok(new IdBean(updatedId)).build();
             }
         } else {
             StorageServiceClient storageClient = StorageServiceClientSingleton.getInstance();
@@ -250,6 +253,7 @@ public class ChallengesResources {
                         SparqlQueries.getChallengeGraphQuery(id, Constants.CHALLENGE_DEFINITION_GRAPH_URI));
                 // update the model only if it has been found
                 if (oldModel != null) {
+                    RdfModelCreationHelper.reduceModelToChallenge(oldModel, oldModel.getResource(challenge.getId()));
                     Model newModel = RdfModelCreationHelper.createNewModel();
                     RdfModelCreationHelper.addChallenge(challenge, newModel);
                     // Create update query from difference
@@ -264,7 +268,8 @@ public class ChallengesResources {
             }
             return Response.ok(new IdBean(id)).build();
         }
-        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found")).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found"))
+                .build();
     }
 
     @DELETE
@@ -296,6 +301,7 @@ public class ChallengesResources {
                 }
             }
         }
-        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found")).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(InfoBean.withMessage("Challenge " + id + " not found"))
+                .build();
     }
 }

--- a/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ChallengesResources.java
+++ b/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ChallengesResources.java
@@ -256,6 +256,7 @@ public class ChallengesResources {
                     RdfModelCreationHelper.reduceModelToChallenge(oldModel, oldModel.getResource(challenge.getId()));
                     Model newModel = RdfModelCreationHelper.createNewModel();
                     RdfModelCreationHelper.addChallenge(challenge, newModel);
+                    RdfModelCreationHelper.reduceModelToChallenge(newModel, newModel.getResource(challenge.getId()));
                     // Create update query from difference
                     storageClient.sendUpdateQuery(SparqlQueries.getUpdateQueryFromDiff(oldModel, newModel,
                             Constants.CHALLENGE_DEFINITION_GRAPH_URI));

--- a/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ExperimentsResources.java
+++ b/hobbit-gui/gui-serverbackend/src/main/java/de/usu/research/hobbit/gui/rest/ExperimentsResources.java
@@ -93,24 +93,30 @@ public class ExperimentsResources {
                     // get public experiment
                     Model model = StorageServiceClientSingleton.getInstance().sendConstructQuery(query);
                     if (model != null && model.size() > 0) {
+                        LOGGER.trace("Got result for {} from the public graph.", id);
                         results.add(RdfModelHelper.createExperimentBean(model, model.getResource(experimentUri)));
+                        LOGGER.trace("Added result bean of {} to the list of results.", id);
                     } else {
+                        LOGGER.trace("Got result for {} from the public graph. Trying the private graph.", id);
                         // if public experiment is not found
                         // try requesting model from private graph
                         query = SparqlQueries.getExperimentGraphQuery(experimentUri,
                                 Constants.PRIVATE_RESULT_GRAPH_URI);
                         model = StorageServiceClientSingleton.getInstance().sendConstructQuery(query);
                         if (model != null && model.size() > 0) {
+                            LOGGER.trace("Got result for {} from the private graph.", id);
                             // get current experiment system
                             Resource subj = model.getResource(experimentUri);
                             Resource system = RdfHelper.getObjectResource(model, subj, HOBBIT.involvesSystemInstance);
                             if (system != null) {
+                                LOGGER.trace("Check visibility of system {}.", system.getURI());
                                 String systemURI = system.getURI();
                                 userOwnedSystemIds = InternalResources.getUserSystemIds(sc);
                                 // check if it's owned by user
                                 if (userOwnedSystemIds.contains(systemURI)) {
                                     results.add(RdfModelHelper.createExperimentBean(model,
                                             model.getResource(experimentUri)));
+                                    LOGGER.trace("Added result bean of {} to the list of results.", id);
                                 }
                             }
                         } else {


### PR DESCRIPTION
Added restrictions for triples which can be updated via a `PUT` request to the challenge REST service. Now, the changes are limited to certain properties of a challenge. For challenge tasks, the registration of systems and the usage of `KPISeq` is excluded.