### PR TITLE
Cache maven and npm stuff on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,8 @@ script:
 services:
   - docker
 sudo: required
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.npm
+    - hobbit-gui/gui-client/node_modules


### PR DESCRIPTION
When tested on a forked repository, that sped up builds by a couple of minutes. Should be merged into `master` to have immediate effect on all builds.