### PR TITLE
Fix generated service names being too long

### DIFF
--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -73,6 +73,8 @@ public class ContainerManagerImpl implements ContainerManager {
     public static final String USER_PASSWORD_KEY = GitlabControllerImpl.GITLAB_TOKEN_KEY;
     public static final String REGISTRY_URL_KEY = "REGISTRY_URL";
 
+    private static final int DOCKER_MAX_NAME_LENGTH = 63;
+
     private static final String DEPLOY_ENV = System.getenv().containsKey(DEPLOY_ENV_KEY)
             ? System.getenv().get(DEPLOY_ENV_KEY)
             : "production";
@@ -224,6 +226,10 @@ public class ContainerManagerImpl implements ContainerManager {
             builder.append('-');
         }
         builder.append(baseName.replaceAll("[/\\.]", "_"));
+        int maxLength = DOCKER_MAX_NAME_LENGTH - 1 - uuid.length();
+        if (builder.length() > maxLength) {
+            builder.setLength(maxLength);
+        }
         builder.append('-');
         builder.append(uuid);
         return builder.toString();

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/LongImageNameTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/LongImageNameTest.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of platform-controller.
+ *
+ * platform-controller is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * platform-controller is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with platform-controller.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.controller.docker;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.hobbit.core.Constants;
+import org.junit.Test;
+
+
+public class LongImageNameTest extends ContainerManagerBasedTest {
+
+    private static final String imageName = "hobbitproject/nonexisting_image_name_thats_too_long";
+
+    @Test
+    public void startContainer() throws Exception {
+        String id = manager.startContainer(imageName, Constants.CONTAINER_TYPE_SYSTEM, null);
+        assertNotNull("ID of started container is not null", id);
+        tasks.add(id);
+    }
+
+}


### PR DESCRIPTION
Truncate image names if resulting service name is too long for docker (#296).