### PR TITLE
Do not actively pull a single image several times during the single experiment

### DIFF
--- a/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/ExperimentManager.java
@@ -303,6 +303,7 @@ public class ExperimentManager implements Closeable {
         usedImages.addAll(benchmark.usedImages);
         // pull all used images
         for (String image : usedImages) {
+            experimentStatus.addImage(image);
             controller.containerManager.pullImage(image);
         }
     }

--- a/platform-controller/src/main/java/org/hobbit/controller/PlatformController.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/PlatformController.java
@@ -514,8 +514,15 @@ public class PlatformController extends AbstractCommandReceivingComponent
             LOGGER.error("Couldn't create container because the parent \"{}\" is not known.", data.parent);
             return null;
         }
+
+        boolean pullImage = false;
+        if (!expManager.experimentStatus.getUsedImages().contains(data.image)) {
+            expManager.experimentStatus.addImage(data.image);
+            pullImage = true;
+        }
+
         String containerId = containerManager.startContainer(data.image, data.type, parentId, data.environmentVariables,
-                null);
+                null, pullImage);
         if (containerId == null) {
             return null;
         } else {

--- a/platform-controller/src/main/java/org/hobbit/controller/data/ExperimentStatus.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/data/ExperimentStatus.java
@@ -19,7 +19,9 @@ package org.hobbit.controller.data;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.Semaphore;
 
@@ -117,6 +119,10 @@ public class ExperimentStatus implements Closeable {
      * Flag indicating whether the benchmark system is ready.
      */
     private boolean systemRunning = false;
+    /**
+     * Set of image names which were used during this experiment.
+     */
+    private Set<String> usedImages = new HashSet<>();
     /**
      * Container name of the system.
      */
@@ -272,6 +278,25 @@ public class ExperimentStatus implements Closeable {
 
     public long getAbortionTimeStamp() {
         return abortionTimeStamp;
+    }
+
+    /**
+     * Adds an image to the set of images used in this experiment.
+     *
+     * @param image
+     *            image name to add
+     */
+    public void addImage(String image) {
+        usedImages.add(image);
+    }
+
+    /**
+     * Adds an image to the set of images used in this experiment.
+     *
+     * @return set of images used in thie experiment
+     */
+    public Set<String> getUsedImages() {
+        return usedImages;
     }
 
     /**

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManager.java
@@ -141,6 +141,27 @@ public interface ContainerManager {
      *            environment variables of the schema "key=value"
      * @param command
      *            commands that should be executed
+     * @param pullImage
+     *            whether the image needs to be prefetched
+     *
+     * @return container Id or null if an error occurred.
+     */
+    public String startContainer(String imageName, String containerType, String parentId, String[] env,
+    String[] command, boolean pullImage);
+
+    /**
+     * Starts the container with the given image name.
+     *
+     * @param imageName
+     *            name of the image to be started
+     * @param containerType
+     *            type to be assigned to container
+     * @param parentId
+     *            id of the parent container
+     * @param env
+     *            environment variables of the schema "key=value"
+     * @param command
+     *            commands that should be executed
      * @param experimentId
      *            experimentId to add to GELF tag
      *

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -139,6 +139,7 @@ public class ContainerManagerImpl implements ContainerManager {
 
     private String gelfAddress = null;
     private String experimentId = null;
+    private Set<String> pulledImages = new HashSet<>();
 
     /**
      * Constructor that creates new docker client instance
@@ -249,6 +250,12 @@ public class ContainerManagerImpl implements ContainerManager {
             LOGGER.warn("Skipping image pulling because DOCKER_AUTOPULL is unset");
             return;
         }
+
+        if (pulledImages.contains(imageName)) {
+            LOGGER.debug("Image {} was already pulled during this experiment", imageName);
+            return;
+        }
+        pulledImages.add(imageName);
 
         LOGGER.info("Pulling the image \"{}\"", imageName);
 
@@ -573,6 +580,9 @@ public class ContainerManagerImpl implements ContainerManager {
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
             String[] command, String experimentId) {
+        if (this.experimentId != experimentId) {
+            pulledImages = new HashSet<>();
+        }
         this.experimentId = experimentId;
         return startContainer(imageName, containerType, parentId, env, command);
     }

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
@@ -259,27 +259,6 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
     }
 
     @Test
-    public void pullTwiceInExperiment() throws Exception {
-        final String testImage = "hello-world";
-        final String experimentId1 = "pullTwiceExperiment1";
-        final String experimentId2 = "pullTwiceExperiment2";
-        // FIXME: all checks should be performed on all nodes in the swarm! Currently it only looks at local node
-
-        // Start a container (sets experiment ID inside the manager).
-        String id = manager.startContainer(testImage, Constants.CONTAINER_TYPE_BENCHMARK, null, null, null, experimentId1);
-        manager.removeContainer(id);
-
-        removeImage(testImage);
-        assertTrue("No test image should exist after removing", !imageExists(testImage));
-
-        manager.pullImage(testImage);
-        assertTrue("No test image should exist after trying to pull it (the second time)", !imageExists(testImage));
-
-        manager.startContainer(testImage, Constants.CONTAINER_TYPE_BENCHMARK, null, null, null, experimentId2);
-        assertTrue("Image exists after starting a container with different experiment ID", imageExists(testImage));
-    }
-
-    @Test
     public void pullPublicImage() throws Exception {
         final String testImage = "hello-world";
         // FIXME: all checks should be performed on all nodes in the swarm! Currently it only looks at local node

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
@@ -259,6 +259,27 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
     }
 
     @Test
+    public void pullTwiceInExperiment() throws Exception {
+        final String testImage = "hello-world";
+        final String experimentId1 = "pullTwiceExperiment1";
+        final String experimentId2 = "pullTwiceExperiment2";
+        // FIXME: all checks should be performed on all nodes in the swarm! Currently it only looks at local node
+
+        // Start a container (sets experiment ID inside the manager).
+        String id = manager.startContainer(testImage, Constants.CONTAINER_TYPE_BENCHMARK, null, null, null, experimentId1);
+        manager.removeContainer(id);
+
+        removeImage(testImage);
+        assertTrue("No test image should exist after removing", !imageExists(testImage));
+
+        manager.pullImage(testImage);
+        assertTrue("No test image should exist after trying to pull it (the second time)", !imageExists(testImage));
+
+        manager.startContainer(testImage, Constants.CONTAINER_TYPE_BENCHMARK, null, null, null, experimentId2);
+        assertTrue("Image exists after starting a container with different experiment ID", imageExists(testImage));
+    }
+
+    @Test
     public void pullPublicImage() throws Exception {
         final String testImage = "hello-world";
         // FIXME: all checks should be performed on all nodes in the swarm! Currently it only looks at local node

--- a/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyContainerManager.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyContainerManager.java
@@ -49,6 +49,12 @@ public class DummyContainerManager implements ContainerManager {
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
+            String[] command, boolean pullImage) {
+        return imageName;
+    }
+
+    @Override
+    public String startContainer(String imageName, String containerType, String parentId, String[] env,
                                  String[] command, String experimentId) {
         return imageName;
     }


### PR DESCRIPTION
This will speed up benchmarks like LDCBench which may want to spawn a lot of similar containers.

Fixes #429.