### PR TITLE
Added the missing metadata directory

### DIFF
--- a/platform-controller/Dockerfile
+++ b/platform-controller/Dockerfile
@@ -1,6 +1,8 @@
 FROM maven
 
 RUN mkdir -p /usr/src/app
+# Create an empty metadata directory (it will be used as default by the file-based image manager)
+RUN mkdir -p /usr/src/app/metadata
 WORKDIR /usr/src/app
 
 ADD . /usr/src/app


### PR DESCRIPTION
Fixed the issue that the default configuration of the platform controller prints a stack trace every minute because of a missing default directory.