### PR TITLE
v2.0.13

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ELK_VERSION=6.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
-  - sudo apt-get --allow-downgrades -y install docker-ce=17.12.1~ce-0~ubuntu
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker --version
   - nvm install 8
   - docker swarm init
   - docker network create -d overlay --attachable hobbit

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,9 @@ lc-run:
 dev:
 	docker-compose -f docker-compose-dev.yml build
 	docker-compose -f docker-compose-dev.yml -f docker-compose.override.yml up
+
+clean:
+	cd analysis-component && mvn clean
+	cd platform-controller && mvn clean
+	cd platform-storage/storage-service && mvn clean
+	cd hobbit-gui/gui-serverbackend && mvn clean

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,10 +3,11 @@ services:
   platform-controller:
     image: hobbitproject/hobbit-platform-controller:dev
     networks:
+      - hobbit
       - hobbit-core
     environment:
+      HOBBIT_RABBIT_IMAGE: "rabbitmq:management"
       HOBBIT_RABBIT_HOST: "rabbit"
-      HOBBIT_RABBIT_EXPERIMENTS_HOST: "rabbit"
       HOBBIT_REDIS_HOST: "redis"
       DEPLOY_ENV: "testing"
       GITLAB_USER: "${GITLAB_USER}"

--- a/docker-compose-elk.yml
+++ b/docker-compose-elk.yml
@@ -1,3 +1,5 @@
+# environment variables (defined in .env file):
+# - ELK_VERSION: Docker image tag to use for elasticsearch, logstash & kibana
 version: '3.3'
 services:
   # ELK logging stack

--- a/docker-compose-elk.yml
+++ b/docker-compose-elk.yml
@@ -6,7 +6,7 @@ services:
       resources:
         limits:
           memory: 8g
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
     command: elasticsearch -E network.host=0.0.0.0
     volumes:
       - ./config/elk/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
@@ -30,7 +30,7 @@ services:
       - hobbit-services
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:5.2.2
+    image: docker.elastic.co/logstash/logstash:${ELK_VERSION}
     command: logstash -f /usr/share/logstash/config/logstash.conf
     environment:
       - constraint:org.hobbit.type==data
@@ -49,7 +49,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.2.2
+    image: docker.elastic.co/kibana/kibana:${ELK_VERSION}
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
       - SERVER_NAME=kibana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ services:
   platform-controller:
     image: hobbitproject/hobbit-platform-controller:latest
     networks:
+      - hobbit
       - hobbit-core
     environment:
+      HOBBIT_RABBIT_IMAGE: "rabbitmq:management"
       HOBBIT_RABBIT_HOST: "rabbit"
-      HOBBIT_RABBIT_EXPERIMENTS_HOST: "rabbit"
       HOBBIT_REDIS_HOST: "redis"
       DEPLOY_ENV: "testing"
       GITLAB_USER: "${GITLAB_USER}"
@@ -27,6 +28,7 @@ services:
       - hobbit
     environment:
       - HOBBIT_RABBIT_HOST=rabbit
+      - HOBBIT_RABBIT_IMAGE=rabbitmq:management
       #- KEYCLOAK_AUTH_URL=http://192.168.99.100:8181/auth
       - KEYCLOAK_AUTH_URL=http://localhost:8181/auth
       - CHECK_REALM_URL=false

--- a/hobbit-gui/gui-client/src/app/app.module.ts
+++ b/hobbit-gui/gui-client/src/app/app.module.ts
@@ -45,6 +45,7 @@ import { CompareComponent } from './experiments/details/compare/compare.componen
 import { GraphComponent } from './experiments/details/graph/graph.component';
 import { PlotComponent } from './experiments/details/plot/plot.component';
 import { BackButtonComponent } from './common/back-button.component';
+import { LoaderComponent } from './common/loader.component';
 
 const appRoutes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -127,7 +128,8 @@ export const mergeStrategyProvide = { provide: LocationStrategy, useClass: Merge
     CompareComponent,
     GraphComponent,
     PlotComponent,
-    BackButtonComponent
+    BackButtonComponent,
+    LoaderComponent,
   ],
   imports: [
     BrowserAnimationsModule,

--- a/hobbit-gui/gui-client/src/app/challenges/edit/edit.component.html
+++ b/hobbit-gui/gui-client/src/app/challenges/edit/edit.component.html
@@ -23,6 +23,9 @@
   <div *ngIf="challenge">
     <form>
       <div class="form-group">
+        <label>URI</label>
+        <br>{{challenge.id}}</div>
+      <div class="form-group">
         <label for="name">Name</label>
         <input type="text" id="name" name="name" [readonly]="!canEdit()" [(ngModel)]="challenge.name" class="form-control" placeholder="Name"
         />

--- a/hobbit-gui/gui-client/src/app/challenges/task/task.component.html
+++ b/hobbit-gui/gui-client/src/app/challenges/task/task.component.html
@@ -23,6 +23,9 @@
     <div class="col-md-12">
       <form>
         <div class="form-group">
+          <label>URI</label>
+          <br>{{task.id}}</div>
+        <div class="form-group">
           <label for="name">Name</label>
           <input type="text" id="name" name="name" [readonly]="!canEdit()" [(ngModel)]="task.name" class="form-control" placeholder="Name"
           />

--- a/hobbit-gui/gui-client/src/app/common/loader.component.less
+++ b/hobbit-gui/gui-client/src/app/common/loader.component.less
@@ -1,0 +1,29 @@
+:host ::ng-deep {
+  div {
+    background: url("/assets/favicon.ico") no-repeat;
+    width: 48px;
+    height: 48px;
+    margin: 1em auto;
+    opacity: 0;
+    animation-name: loaderAppear, loaderRotate;
+    animation-duration: 1s, 2s;
+    animation-delay: 2s;
+    animation-direction: alternate, normal;
+    animation-iteration-count: 1, infinite;
+    animation-fill-mode: both;
+    animation-timing-function: ease-in, linear;
+  }
+  @keyframes loaderAppear {
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes loaderRotate {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  span {
+    display: none;
+  }
+}

--- a/hobbit-gui/gui-client/src/app/common/loader.component.ts
+++ b/hobbit-gui/gui-client/src/app/common/loader.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-loader',
+  template: '<div><span>Loading...</span></div>',
+  styleUrls: ['./loader.component.less'],
+})
+export class LoaderComponent {
+}

--- a/hobbit-gui/gui-client/src/app/experiments/details/details.component.html
+++ b/hobbit-gui/gui-client/src/app/experiments/details/details.component.html
@@ -1,3 +1,6 @@
+<div *ngIf="!loaded">
+  <app-loader></app-loader>
+</div>
 <div *ngIf="loaded">
   <div *ngIf="!rows">
     <p>No experiment results found</p>

--- a/hobbit-gui/gui-client/src/app/experiments/details/details.component.ts
+++ b/hobbit-gui/gui-client/src/app/experiments/details/details.component.ts
@@ -84,8 +84,8 @@ export class DetailsComponent implements OnInit, OnChanges {
         this.buildTableRows(this.details);
 
       this.sameBenchmark = new Set(this.experiments.filter(ex => ex.benchmark).map(ex => ex.benchmark.id)).size === 1;
+      this.loaded = true;
     });
-    this.loaded = true;
   }
 
   private buildTableRows(experiments) {
@@ -108,6 +108,9 @@ export class DetailsComponent implements OnInit, OnChanges {
     }
 
     this.rows = [];
+
+    // FIXME server should send the real experiment URI
+    this.rows.push(this.buildRow('Experiment', 'URI', 'Permanent URI of the experiment', t => ['http://w3id.org/hobbit/experiments#' + t.id, '']));
 
     this.rows.push(this.buildRow('Experiment', 'Benchmark', 'The benchmark performed', t => DetailsComponent.safeNameAndDescription(t.benchmark)));
     this.rows.push(this.buildRow('Experiment', 'System', 'The system evaluated', t => DetailsComponent.safeNameAndDescription(t.system)));

--- a/hobbit-gui/gui-client/src/app/experiments/experiments.component.html
+++ b/hobbit-gui/gui-client/src/app/experiments/experiments.component.html
@@ -13,6 +13,9 @@
   </app-page-header>
 </div>
 <div class="container-fluid">
+  <div *ngIf="!loaded">
+    <app-loader></app-loader>
+  </div>
   <div *ngIf="loaded">
     <div class="row">
       <div class="col-md-12">

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -8,11 +8,11 @@
 
     <!-- PROPERTIES -->
     <properties>
-        <hobbitplatform.version>2.0.12</hobbitplatform.version>
+        <hobbitplatform.version>2.0.13</hobbitplatform.version>
         <java.version>1.8</java.version>
         <slf4j.version>1.7.10</slf4j.version>
         <lucene.version>4.4.0</lucene.version>
-        <junit.version>4.8.2</junit.version>
+        <junit.version>4.13.1</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.hobbit</groupId>
                 <artifactId>core</artifactId>
-                <version>1.0.18</version>
+                <version>1.0.19</version>
             </dependency>
             <!-- RabbitMQ -->
             <dependency>
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <!-- Apache Commons Lang 3 -->
             <dependency>

--- a/platform-controller/Makefile
+++ b/platform-controller/Makefile
@@ -16,8 +16,11 @@ run:
 		org.hobbit.controller.PlatformController
 
 test:
+	# Without HOBBIT_RABBIT_EXPERIMENTS_HOST we will be not be able to connect to the RabbitMQ platform will create.
 	docker-compose --file=../docker-compose-dev.yml up -d cadvisor node-exporter prometheus rabbit redis
+	HOBBIT_RABBIT_IMAGE=rabbitmq:management \
 	HOBBIT_RABBIT_HOST=localhost \
+	HOBBIT_RABBIT_EXPERIMENTS_HOST=localhost \
 	HOBBIT_REDIS_HOST=localhost \
 	PROMETHEUS_HOST=localhost \
 	mvn --update-snapshots -Dtest=$(test) clean test

--- a/platform-controller/pom.xml
+++ b/platform-controller/pom.xml
@@ -57,13 +57,13 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <!-- Docker Client -->
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.11.2</version>
+            <version>8.16.0</version>
         </dependency>
         <!-- JSON lib -->
         <dependency>

--- a/platform-controller/src/main/java/org/hobbit/controller/data/ExperimentStatus.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/data/ExperimentStatus.java
@@ -124,6 +124,14 @@ public class ExperimentStatus implements Closeable {
      */
     private Set<String> usedImages = new HashSet<>();
     /**
+     * Name of the root service for this experiment.
+     */
+    private String rootContainer = null;
+    /**
+     * Container name of the RabbitMQ service for this experiment.
+     */
+    private String rabbitMQContainer = null;
+    /**
      * Container name of the system.
      */
     private String benchmarkContainer = null;
@@ -254,6 +262,22 @@ public class ExperimentStatus implements Closeable {
 
     public void setSystemRunning(boolean systemRunning) {
         this.systemRunning = systemRunning;
+    }
+
+    public String getRootContainer() {
+        return rootContainer;
+    }
+
+    public void setRootContainer(String rootContainer) {
+        this.rootContainer = rootContainer;
+    }
+
+    public String getRabbitMQContainer() {
+        return rabbitMQContainer;
+    }
+
+    public void setRabbitMQContainer(String rabbitMQContainer) {
+        this.rabbitMQContainer = rabbitMQContainer;
     }
 
     public String getBenchmarkContainer() {

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManager.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManager.java
@@ -35,7 +35,7 @@ public interface ContainerManager {
      * Exit code of containers
      * where process was terminated with SIGKILL (number 9).
      */
-    public static int DOCKER_EXITCODE_SIGKILL = 128 + 9;
+    public static long DOCKER_EXITCODE_SIGKILL = 128 + 9;
 
     /**
      * Label that denotes container type
@@ -255,7 +255,7 @@ public interface ContainerManager {
      *
      * @param container
      */
-    public Integer getContainerExitCode(String serviceName) throws DockerException, InterruptedException;
+    public Long getContainerExitCode(String serviceName) throws DockerException, InterruptedException;
 
     /**
      * Returns container info

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerManagerImpl.java
@@ -602,7 +602,7 @@ public class ContainerManagerImpl implements ContainerManager {
     @Override
     public void removeContainer(String serviceName) {
         try {
-            Integer exitCode = getContainerExitCode(serviceName);
+            Long exitCode = getContainerExitCode(serviceName);
             if (DEPLOY_ENV.equals(DEPLOY_ENV_DEVELOP)) {
                 LOGGER.info(
                         "Will not remove container {}. "
@@ -692,7 +692,7 @@ public class ContainerManagerImpl implements ContainerManager {
     }
 
     @Override
-    public Integer getContainerExitCode(String serviceName) throws DockerException, InterruptedException {
+    public Long getContainerExitCode(String serviceName) throws DockerException, InterruptedException {
         if (getContainerInfo(serviceName) == null) {
             LOGGER.warn("Couldn't get the exit code for container {}. Service doesn't exist. Assuming it was stopped by the platform.", serviceName);
             return DOCKER_EXITCODE_SIGKILL;
@@ -708,10 +708,10 @@ public class ContainerManagerImpl implements ContainerManager {
         for (Task task : tasks) {
             if (!UNFINISHED_TASK_STATES.contains(task.status().state())) {
                 // Task is finished.
-                Integer exitCode = task.status().containerStatus().exitCode();
+                Long exitCode = task.status().containerStatus().exitCode();
                 if (exitCode == null) {
                     LOGGER.warn("Couldn't get the exit code for container {}. Task is finished. Returning 0.", serviceName);
-                    return 0;
+                    return 0l;
                 }
                 return exitCode;
             }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerStateObserverImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerStateObserverImpl.java
@@ -94,7 +94,7 @@ public class ContainerStateObserverImpl implements ContainerStateObserver {
                 }
                 for (String id : containerIds) {
                     try {
-                        Integer exitStatus = manager.getContainerExitCode(id);
+                        Long exitStatus = manager.getContainerExitCode(id);
 
                         if (exitStatus != null) {
                             // notify all callbacks

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerTerminationCallback.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerTerminationCallback.java
@@ -34,5 +34,5 @@ public interface ContainerTerminationCallback {
      * @param exitCode
      *            the exit code of the container
      */
-    public void notifyTermination(String containerId, int exitCode);
+    public void notifyTermination(String containerId, long exitCode);
 }

--- a/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerTerminationCallbackImpl.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/docker/ContainerTerminationCallbackImpl.java
@@ -21,10 +21,10 @@ package org.hobbit.controller.docker;
  */
 public class ContainerTerminationCallbackImpl implements ContainerTerminationCallback {
     public String containerId;
-    public int exitCode;
+    public long exitCode;
 
     @Override
-    public void notifyTermination(String containerId, int exitCode) {
+    public void notifyTermination(String containerId, long exitCode) {
         this.containerId = containerId;
         this.exitCode = exitCode;
     }

--- a/platform-controller/src/main/java/org/hobbit/controller/utils/RabbitMQConnector.java
+++ b/platform-controller/src/main/java/org/hobbit/controller/utils/RabbitMQConnector.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of platform-controller.
+ *
+ * platform-controller is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * platform-controller is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with platform-controller.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.hobbit.controller.utils;
+
+import org.hobbit.controller.PlatformController;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.commons.io.Charsets;
+import org.hobbit.core.components.AbstractCommandReceivingComponent;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
+
+/**
+ * This class connects the controller to the experiment's command queue.
+ */
+public class RabbitMQConnector extends AbstractCommandReceivingComponent {
+    /**
+     * The controller this connector belongs to.
+     */
+    private PlatformController controller;
+
+    /**
+     * Constructor needed for testing.
+     */
+    public RabbitMQConnector(PlatformController controller, String rabbitMQHostName) {
+        super();
+        this.controller = controller;
+        this.rabbitMQHostName = rabbitMQHostName;
+    }
+
+    @Override
+    public void run() throws Exception {
+        throw new IllegalStateException();
+    }
+
+    /**
+     * The controller overrides the super method because it does not need to check
+     * for the leading hobbit id and delegates the command handling to the
+     * {@link #receiveCommand(byte, byte[], String, String)} method.
+     */
+    @Override
+    protected void handleCmd(byte bytes[], AMQP.BasicProperties props) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        int idLength = buffer.getInt();
+        byte sessionIdBytes[] = new byte[idLength];
+        buffer.get(sessionIdBytes);
+        String sessionId = new String(sessionIdBytes, Charsets.UTF_8);
+        byte command = buffer.get();
+        byte remainingData[];
+        if (buffer.remaining() > 0) {
+            remainingData = new byte[buffer.remaining()];
+            buffer.get(remainingData);
+        } else {
+            remainingData = new byte[0];
+        }
+        controller.receiveCommand(command, remainingData, sessionId, props);
+    }
+
+    public void basicPublish(String exchange, String routingKey, BasicProperties props, byte[] body) throws IOException {
+        cmdChannel.basicPublish(exchange, routingKey, props, body);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{rabbitMQHostName=%s}", this.rabbitMQHostName);
+    }
+
+    ///// There are some methods that shouldn't be used by the controller and
+    ///// have been marked as deprecated
+
+    /**
+     * @deprecated Not used inside the controller. Use
+     *             {@link #receiveCommand(byte, byte[], String, String)} instead.
+     */
+    @Deprecated
+    @Override
+    public void receiveCommand(byte command, byte[] data) {
+        throw new IllegalStateException();
+    }
+}

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerAccessByHostnameTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerAccessByHostnameTest.java
@@ -40,7 +40,7 @@ public class ContainerAccessByHostnameTest extends ContainerManagerBasedTest {
 
         dockerClient.connectToNetwork(clientContainer, ContainerManagerImpl.HOBBIT_DOCKER_NETWORK);
         dockerClient.startContainer(clientContainer);
-        int clientStatusCode = dockerClient.waitContainer(clientContainer).statusCode();
+        long clientStatusCode = dockerClient.waitContainer(clientContainer).statusCode();
         assertEquals("Ping exit code", 0, clientStatusCode);
     }
 

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerManagerImplTest.java
@@ -325,13 +325,13 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
         String testTask = manager.startContainer(testImage, Constants.CONTAINER_TYPE_SYSTEM, null);
         services.add(testTask);
         // check if the started service uses the first version of image
-        Integer exitCode = null;
+        Long exitCode = null;
         while (exitCode == null) {
             Thread.sleep(500);
             exitCode = manager.getContainerExitCode(testTask);
         }
         assertEquals("Service is using first image version",
-                Integer.valueOf(1), exitCode);
+                Long.valueOf(1), exitCode);
         manager.removeContainer(testTask);
         services.remove(testTask);
         // build second version of image
@@ -351,16 +351,16 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
             exitCode = manager.getContainerExitCode(testTask);
         }
         assertEquals("Service is using second image version",
-                Integer.valueOf(2), exitCode);
+                Long.valueOf(2), exitCode);
     }
 
-    private Integer getContainerEnvValue(String envVariable) throws DockerException, InterruptedException {
+    private Long getContainerEnvValue(String envVariable) throws DockerException, InterruptedException {
         String id = manager.startContainer(busyboxImageName, Constants.CONTAINER_TYPE_SYSTEM, null,
                 new String[]{"sh", "-c", "exit $" + envVariable});
         assertNotNull(id);
         services.add(id);
 
-        Integer exitCode = null;
+        Long exitCode = null;
         while (exitCode == null) {
             Thread.sleep(500);
 
@@ -370,7 +370,7 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
 
                 if (taskInfo.status().state().equals(TaskStatus.TASK_STATE_COMPLETE) && exitCode == null) {
                     // assume exit code 0
-                    exitCode = 0;
+                    exitCode = 0l;
                 }
             }
         }
@@ -381,9 +381,9 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
 
     @Test(timeout=60000)
     public void environmentNodesInformation() throws Exception {
-        Integer nodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_NODES_KEY);
-        Integer systemNodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_SYSTEM_NODES_KEY);
-        Integer benchmarkNodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_BENCHMARK_NODES_KEY);
+        Long nodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_NODES_KEY);
+        Long systemNodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_SYSTEM_NODES_KEY);
+        Long benchmarkNodes = getContainerEnvValue(Constants.HARDWARE_NUMBER_OF_BENCHMARK_NODES_KEY);
 
         assertTrue("Total nodes should be > 0 (got " + nodes + ")",
             nodes > 0);
@@ -418,13 +418,13 @@ public class ContainerManagerImplTest extends ContainerManagerBasedTest {
         assertNotNull(pingContainer);
         services.add(pingContainer);
         Thread.sleep(10000);
-        assertEquals("Result of pinging the container's network alias", (Integer)0, manager.getContainerExitCode(pingContainer));
+        assertEquals("Result of pinging the container's network alias", Long.valueOf(0), manager.getContainerExitCode(pingContainer));
 
         pingContainer = manager.startContainer(busyboxImageName, Constants.CONTAINER_TYPE_BENCHMARK,
                 null, null, null, new String[]{"ping", "-c", "1", "-W", "2", "nonexistant"});
         assertNotNull(pingContainer);
         services.add(pingContainer);
         Thread.sleep(10000);
-        assertEquals("Result of pinging the nonexisting host", (Integer)1, manager.getContainerExitCode(pingContainer));
+        assertEquals("Result of pinging the nonexisting host", Long.valueOf(1), manager.getContainerExitCode(pingContainer));
     }
 }

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerStateObserverImplTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ContainerStateObserverImplTest.java
@@ -66,7 +66,7 @@ public class ContainerStateObserverImplTest extends ContainerManagerBasedTest {
         // step two
         ContainerTerminationCallbackImpl cb2 = new ContainerTerminationCallbackImpl() {
             @Override
-            public void notifyTermination(String containerId, int exitCode) {
+            public void notifyTermination(String containerId, long exitCode) {
                 try {
                     // check that correct values were set
                     assertEquals(containerId, containerTwoId);
@@ -86,7 +86,7 @@ public class ContainerStateObserverImplTest extends ContainerManagerBasedTest {
         // step one
         ContainerTerminationCallbackImpl cb1 = new ContainerTerminationCallbackImpl() {
             @Override
-            public void notifyTermination(String containerId, int exitCode) {
+            public void notifyTermination(String containerId, long exitCode) {
                 try {
                     // check that correct values were set
                     assertEquals("Container ID", containerOneId, containerId);

--- a/platform-controller/src/test/java/org/hobbit/controller/docker/ResourceInformationCollectorTest.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/docker/ResourceInformationCollectorTest.java
@@ -39,6 +39,9 @@ public class ResourceInformationCollectorTest extends ContainerManagerBasedTest 
 
     @Test
     public void test() throws Exception {
+        LOGGER.info("Waiting to avoid failing container creation, which happens when running the full test suite...");
+        Thread.sleep(10000);
+
         LOGGER.info("Creating first container...");
         String containerId = manager.startContainer(busyboxImageName,
                 Constants.CONTAINER_TYPE_SYSTEM, null, sleepCommand);
@@ -110,11 +113,11 @@ public class ResourceInformationCollectorTest extends ContainerManagerBasedTest 
 
         Assert.assertNotNull("CPU stats", usage.getCpuStats());
         /* FIXME cpu usage */
-        Assert.assertTrue("CPU usage > 0", usage.getCpuStats().getTotalUsage() > 0);
+        Assert.assertTrue("CPU usage > 0", usage.getCpuStats().getTotalUsage() > 0l);
         Assert.assertNotNull("Memory stats", usage.getMemoryStats());
-        Assert.assertTrue("Memory usage > 0", usage.getMemoryStats().getUsageSum() > 0);
+        Assert.assertTrue("Memory usage > 0", usage.getMemoryStats().getUsageSum() > 0l);
         Assert.assertNotNull("Disk stats", usage.getDiskStats());
-        Assert.assertTrue("Disk fs size > 0", usage.getDiskStats().getFsSizeSum() > 0);
+        Assert.assertTrue("Disk fs size > 0", usage.getDiskStats().getFsSizeSum() > 0l);
 
         LOGGER.info("Waiting for the container {} to generate its file...",
                 containerId);

--- a/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyContainerManager.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyContainerManager.java
@@ -21,54 +21,58 @@ public class DummyContainerManager implements ContainerManager {
         this.terminationCallback = terminationCallback;
     }
 
+    private String containerName(String imageName) {
+        return imageName.replaceFirst(":.*$", "");
+    }
+
     @Override
     public String startContainer(String imageName) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String[] command) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String type, String parent) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] command) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
             String[] command) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
             String[] command, boolean pullImage) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
                                  String[] netAliases, String[] command) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
                                  String[] netAliases, String[] command, boolean pullImage) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
     public String startContainer(String imageName, String containerType, String parentId, String[] env,
                                  String[] netAliases, String[] command, String experimentId) {
-        return imageName;
+        return containerName(imageName);
     }
 
     @Override
@@ -111,7 +115,7 @@ public class DummyContainerManager implements ContainerManager {
     }
 
     @Override
-    public Integer getContainerExitCode(String serviceName) {
+    public Long getContainerExitCode(String serviceName) {
         return null;
     }
 

--- a/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyPlatformController.java
+++ b/platform-controller/src/test/java/org/hobbit/controller/mocks/DummyPlatformController.java
@@ -38,7 +38,7 @@ public class DummyPlatformController extends PlatformController {
     }
 
     @Override
-    public void notifyTermination(String containerId, int exitCode) {
+    public void notifyTermination(String containerId, long exitCode) {
         expManager.notifyTermination(containerId, exitCode);
     }
 


### PR DESCRIPTION
Added new feature to spawn a new RabbitMQ instance for each experiment. Needs HOBBIT_RABBIT_IMAGE to be passed to the platform controller. If not using that, it's now required to pass HOBBIT_RABBIT_EXPERIMENTS_HOST. This change does not affect benchmarks and systems used with HOBBIT.
Fixed critical issues with the latest Docker version. Now Docker version 19.03.13 is supported.
Fixed some UI issues.